### PR TITLE
Fix: Error "Cannot use object of type stdClass as array" 

### DIFF
--- a/classes/SnippetLoader.php
+++ b/classes/SnippetLoader.php
@@ -165,11 +165,11 @@ class SnippetLoader
 	 *
 	 * @return string
 	 */
-	protected static function getMapCacheKey()
+    protected static function getMapCacheKey()
     {
-		$theme = Theme::getActiveTheme();
-		$page = CmsController::getController()->getPage();
+        $theme = Theme::getActiveTheme();
+        $page = CmsController::getController()->getRouter();
 
-        return crc32($theme->getPath() . $page['url']) . '-dynamic-snippet-map';
+        return crc32($theme->getPath() . $page->getUrl()) . '-dynamic-snippet-map';
     }
 }


### PR DESCRIPTION
Hey,
I am not sure if something changed in the last 11 months but the plugin doesn't work for me without this fix.

Problem is 
![image](https://user-images.githubusercontent.com/52965221/61385542-def8c080-a8b2-11e9-8294-648224022243.png)
