### PR TITLE
Fix script duplication when using RainLab.Pages >= 1.3.5

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -59,13 +59,13 @@ class Plugin extends PluginBase
 
         RichEditor::extend(function($widget) {
             // Adds default CSS/JS for snippets from Rainlab Pages Plugin
-            $widget->addCss('/plugins/rainlab/pages/assets/css/pages.css');
-            $widget->addJs('/plugins/rainlab/pages/assets/js/pages-page.js');
-            $widget->addJs('/plugins/rainlab/pages/assets/js/pages-snippets.js');
+            $widget->addCss('/plugins/rainlab/pages/assets/css/pages.css', 'RainLab.Pages');
+            $widget->addJs('/plugins/rainlab/pages/assets/js/pages-page.js', 'RainLab.Pages');
+            $widget->addJs('/plugins/rainlab/pages/assets/js/pages-snippets.js', 'RainLab.Pages');
 
             // Adds custom javascript
             $widget->addJs('/inetis/snippets/list');
-            $widget->addJs('/plugins/inetis/richeditorsnippets/assets/js/froala.snippets.plugin.js');
+            $widget->addJs('/plugins/inetis/richeditorsnippets/assets/js/froala.snippets.plugin.js', 'Inetis.RicheditorSnippets');
         });
 
         // Register components from cache for AJAX handlers

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -15,3 +15,6 @@
     - Handlers cache is no more shared between users
 2.1.3:
     - Fix broken error message when a snippet is not found - Thanks to Tobias Kündig
+2.1.4:
+    - Fix duplicate stuff on RainLab.Pages (open page twice, add snippet twice, etc.)
+    - '!!! This update fixes a compatibility issue with RainLab.Pages >= v1.3.5. You should make sure you are using the latest version of RainLab.Pages'


### PR DESCRIPTION
Fixes #12 and all other potential duplicate actions (page opens twice, snippet inserted twice, etc.) when using `RainLab.Pages` v1.3.5

Note: this fix will introduce the same duplication issues to systems using `RainLab.Pages` older than 1.3.5. It is strongly advised to update `RainLab.Pages` or stay on version 2.1.3 of this plugin.